### PR TITLE
dt2s: Add an overlay to control dt2s on lockscreen

### DIFF
--- a/core/res/res/values/ex_config.xml
+++ b/core/res/res/values/ex_config.xml
@@ -74,6 +74,9 @@
 
     <!-- True if the notifications should dynamically tint the app icon and app title -->
     <bool name="config_allowNotificationIconTextTinting">true</bool>
+
+    <!-- Enable full screen DT2S in lockscreen -->
+    <bool name="fullScreenDT2S">false</bool>
 </resources>
 
 

--- a/core/res/res/values/ex_symbols.xml
+++ b/core/res/res/values/ex_symbols.xml
@@ -97,6 +97,9 @@
   <!-- Notification sender text color -->
   <java-symbol type="color" name="sender_text_color" />
 
+  <!-- Enable full screen DT2S in lockscreen -->
+  <java-symbol type="bool" name="fullScreenDT2S" />
+
 </resources>
 
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -867,14 +867,24 @@ public class NotificationPanelView extends PanelView implements
             return false;
         }
         final int h = getMeasuredHeight();
-        if ((mIsLockscreenDoubleTapEnabled
-                && mStatusBarState == StatusBarState.KEYGUARD
-                && (event.getY() < (h / 3) ||
-                event.getY() > (h - mStatusBarHeaderHeight))) ||
-                (!mQsExpanded && mDoubleTapToSleepEnabled
-                && event.getY() < mStatusBarHeaderHeight)) {
-            mDoubleTapToSleepGesture.onTouchEvent(event);
-        }
+
+        if(!getResources().getBoolean(com.android.internal.R.bool.fullScreenDT2S)) {
+	        if ((mIsLockscreenDoubleTapEnabled
+        	        && mStatusBarState == StatusBarState.KEYGUARD
+        	        && (event.getY() < (h / 3) ||
+        	        event.getY() > (h - mStatusBarHeaderHeight))) ||
+        	        (!mQsExpanded && mDoubleTapToSleepEnabled
+        	        && event.getY() < mStatusBarHeaderHeight)) {
+        	    mDoubleTapToSleepGesture.onTouchEvent(event);
+        	}
+	} else {
+	        if ((mIsLockscreenDoubleTapEnabled
+	                && mStatusBarState == StatusBarState.KEYGUARD) ||
+        	        (!mQsExpanded && mDoubleTapToSleepEnabled
+        	        && event.getY() < mStatusBarHeaderHeight)) {
+        	    mDoubleTapToSleepGesture.onTouchEvent(event);
+        	}
+	}
         initDownStates(event);
         if (mListenForHeadsUp && !mHeadsUpTouchHelper.isTrackingHeadsUp()
                 && mHeadsUpTouchHelper.onInterceptTouchEvent(event)) {


### PR DESCRIPTION
set fullScreenDT2S to false to make dt2s working only on top of lock screen
set fullScreenDT2S to true to make dt2s working on top and bottom lock screen

Change-Id: Iffa54ae0889db12de1f85579bd662f9dfdebdfb3