### PR TITLE
fw/b: Return a KeyEvent instead of a boolean in KeyHandler

### DIFF
--- a/core/java/com/android/internal/os/DeviceKeyHandler.java
+++ b/core/java/com/android/internal/os/DeviceKeyHandler.java
@@ -20,7 +20,7 @@ public interface DeviceKeyHandler {
      * this special keys prior to pass the key to the active app.
      *
      * @param event The key event to be handled
-     * @return If the event is consume
+     * @return null if event is consumed, KeyEvent to be handled otherwise
      */
-    public boolean handleKeyEvent(KeyEvent event);
+    public KeyEvent handleKeyEvent(KeyEvent event);
 }

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -4318,7 +4318,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         if (mDeviceKeyHandler != null) {
             try {
                 // The device only should consume known keys.
-                if (mDeviceKeyHandler.handleKeyEvent(event)) {
+                event = mDeviceKeyHandler.handleKeyEvent(event);
+                if (event == null) {
                     return -1;
                 }
             } catch (Exception e) {
@@ -6479,7 +6480,8 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         if (mDeviceKeyHandler != null) {
             try {
                 // The device only should consume known keys.
-                if (mDeviceKeyHandler.handleKeyEvent(event)) {
+                event = mDeviceKeyHandler.handleKeyEvent(event);
+                if (event == null) {
                     return 0;
                 }
             } catch (Exception e) {


### PR DESCRIPTION
* Allows handlers to modify the event before sending it off
  to another KeyHandler class, to handle things like rotation

Change-Id: I481107e050f6323c5897260a5d241e64b4e031ac
Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>